### PR TITLE
Fixed "Undefined index" PHP notice on custom post types

### DIFF
--- a/code_gallery.php
+++ b/code_gallery.php
@@ -92,6 +92,8 @@ function cpm_gallery_updated_messages( $messages ) {
 	$post_type        = get_post_type( $post );
 	$post_type_object = get_post_type_object( $post_type );
 
+	if ( $post_type !== 'code_gallery' ) return $messages;
+
 	$messages['code_gallery'] = array(
 		0  => '', // Unused. Messages start at index 1.
 		1  => __( 'Gallery updated.', '_cp' ),


### PR DESCRIPTION
Notice: Undefined index: drink in /Users/Admin/Code/www/buzo.dev/wp-content/plugins/cpm-gallery/code_gallery.php on line 117

Notice: Undefined offset: 1 in /Users/Admin/Code/www/buzo.dev/wp-content/plugins/cpm-gallery/code_gallery.php on line 117

Notice: Undefined offset: 6 in /Users/Admin/Code/www/buzo.dev/wp-content/plugins/cpm-gallery/code_gallery.php on line 118

Notice: Undefined offset: 9 in /Users/Admin/Code/www/buzo.dev/wp-content/plugins/cpm-gallery/code_gallery.php on line 119

Notice: Undefined offset: 8 in /Users/Admin/Code/www/buzo.dev/wp-content/plugins/cpm-gallery/code_gallery.php on line 123

Notice: Undefined offset: 10 in /Users/Admin/Code/www/buzo.dev/wp-content/plugins/cpm-gallery/code_gallery.php on line 124